### PR TITLE
Add start measurement and power control API

### DIFF
--- a/src/senseair.rs
+++ b/src/senseair.rs
@@ -498,6 +498,21 @@ where
         }
     }
 
+    /// Powers on the sensor using the optional enable pin.
+    pub fn power_on(&mut self) {
+        self.en_pin_set();
+    }
+
+    /// Powers off the sensor by resetting the optional enable pin.
+    pub fn power_off(&mut self) {
+        self.en_pin_reset();
+    }
+
+    /// Issues a start measurement command to the sensor.
+    pub fn start_measurement(&mut self) -> Result<(), E> {
+        self.write_register(Registers::StartMesurement, &[0x01], RAM_DELAY)
+    }
+
     /// Retrieves the sensor's configuration values from the sensor's EEPROM registers.
     pub fn get_config(&mut self) -> Result<Config, E> {
         let mut buf = [0u8; 2];


### PR DESCRIPTION
## Summary
- add `power_on`, `power_off`, and `start_measurement` methods for Sunrise sensor

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_68868399a2a48322a7ce478bbd02b964